### PR TITLE
Manual renovate 20250806

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -27,9 +27,9 @@ jobs:
         run: |
           go install gotest.tools/gotestsum@v1.11.0
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.5
+          version: v2.3.0
           working-directory: .
           args: -v --timeout=10m
       - name: Build

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See the [Magic doc](https://magic.link/docs/api-reference/server-side-sdks/go)!
 
 ## Installation
 
-The SDK requires **Go 1.24.0** and Go Modules. To make sure your project is using Go Modules, check for a `go.mod` file in your project's root directory. If it exists, you're already set up; if not, please follow [this guide](https://blog.golang.org/migrating-to-go-modules) to migrate to Go Modules.
+The SDK requires **Go 1.24.5** and Go Modules. To make sure your project is using Go Modules, check for a `go.mod` file in your project's root directory. If it exists, you're already set up; if not, please follow [this guide](https://blog.golang.org/migrating-to-go-modules) to migrate to Go Modules.
 
 Simply reference the SDK in your Go program with an `import`:
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/yukia3e/magic-admin-go
 
-go 1.24
+go 1.24.5
 
 require (
-	github.com/ethereum/go-ethereum v1.15.10
+	github.com/ethereum/go-ethereum v1.16.1
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/stretchr/testify v1.10.0
-	github.com/urfave/cli/v2 v2.27.6
+	github.com/urfave/cli/v2 v2.27.7
 )
 
 require (

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-go = "1.24.2"
-golangci-lint = "2.1.5"
+go = "1.24.5"
+golangci-lint = "2.3.0"


### PR DESCRIPTION
## Update
- chore(deps): update dependency go to v1.24.5 #22
- fix(deps): update module github.com/urfave/cli/v2 to v2.27.7 #23
- chore(deps): update dependency golangci-lint to v2.3.0 #13
- fix(deps): update module github.com/ethereum/go-ethereum to v1.16.1 #14
- chore(deps): update golangci/golangci-lint-action action to v8 #21